### PR TITLE
Improve interactables logic

### DIFF
--- a/src/abstract_base_classes/interactable.gd
+++ b/src/abstract_base_classes/interactable.gd
@@ -13,3 +13,8 @@ func _ready() -> void:
 
 func interact(_player: Player):
 	pass
+
+## The condition in which the object can be interacted with.
+## e.g. an empty clicker holder requires the player to have a clicker
+func interact_condition(_player: Player) -> bool:
+	return true

--- a/src/abstract_base_classes/interactable.gd
+++ b/src/abstract_base_classes/interactable.gd
@@ -3,18 +3,13 @@ class_name Interactable
 
 @onready var interact_label: Label = $InteractLabel
 
+var highlighted: bool = false:
+	set(value):
+		interact_label.visible = value
+		highlighted = value
+
 func _ready() -> void:
-	body_entered.connect(_on_body_entered)
-	body_exited.connect(_on_body_exited)
 	interact_label.hide()
 
 func interact(_player: Player):
 	pass
-
-func _on_body_entered(body: Node2D) -> void:
-	if body is Player:
-		interact_label.show()
-
-func _on_body_exited(body: Node2D) -> void:
-	if body is Player:
-		interact_label.hide()

--- a/src/level_elements/clicker.gd
+++ b/src/level_elements/clicker.gd
@@ -17,6 +17,9 @@ func interact(player: Player):
 	player.has_clicker = true
 	body.queue_free()
 
+func interact_condition(player: Player):
+	return !player.has_clicker
+
 func _on_area_entered(area: Area2D):
 	if not area is ClickerHolder:
 		return

--- a/src/level_elements/clicker_holder.gd
+++ b/src/level_elements/clicker_holder.gd
@@ -24,16 +24,18 @@ func _ready():
 		has_clicker = Global.clicker_state[id]
 
 func interact(player: Player):
-	if has_clicker != player.has_clicker:
-		# exchange clicker with player
-		player.has_clicker = has_clicker
-		has_clicker = !has_clicker
-		# save global clicker state and level unlocks
-		Global.clicker_state[id] = has_clicker
-		if has_clicker and unlocks_level:
-			Global.unlock_level(unlocks_level)
-		# enable all AGs
-		enable_ags()
+	# exchange clicker with player
+	player.has_clicker = has_clicker
+	has_clicker = !has_clicker
+	# save global clicker state and level unlocks
+	Global.clicker_state[id] = has_clicker
+	if has_clicker and unlocks_level:
+		Global.unlock_level(unlocks_level)
+	# enable all AGs
+	enable_ags()
+
+func interact_condition(player: Player):
+	return has_clicker != player.has_clicker
 
 func enable_ags():
 	get_tree().call_group("AGs", "enable")

--- a/src/levels/sandbox.tscn
+++ b/src/levels/sandbox.tscn
@@ -31,8 +31,7 @@ position = Vector2(-410, -136)
 
 [node name="ClickerHolder2" parent="." instance=ExtResource("5_iwbtf")]
 z_index = -1
-position = Vector2(-1367, -136)
-has_clicker = false
+position = Vector2(-687, -136)
 
 [node name="ArtificialGravity" parent="." instance=ExtResource("4_5j5cm")]
 position = Vector2(777, -683)

--- a/src/player/player.gd
+++ b/src/player/player.gd
@@ -238,7 +238,9 @@ func jump_end():
 		velocity.y -= PLAYER.JUMP_RELEASE_SLOWDOWN * velocity.y
 
 func handle_nearby_interactables():
-	var nearby_interactables = interactable_detector.get_overlapping_areas()
+	var nearby_interactables = interactable_detector.get_overlapping_areas().filter(
+		func(interactable): return interactable.interact_condition(self)
+	)
 	if nearby_interactables.is_empty():
 		highlighted_interactable = null
 	else:

--- a/src/player/player.gd
+++ b/src/player/player.gd
@@ -245,7 +245,7 @@ func handle_nearby_interactables():
 		highlighted_interactable = null
 	else:
 		var distance_to = func(node):
-			return global_position.distance_squared_to(node.global_position)
+			return interactable_detector.global_position.distance_squared_to(node.global_position)
 		nearby_interactables.sort_custom(
 			func(a, b): return distance_to.call(a) < distance_to.call(b)
 		)

--- a/src/player/player.tscn
+++ b/src/player/player.tscn
@@ -141,11 +141,12 @@ collision_mask = 4
 shape = SubResource("RectangleShape2D_163mm")
 
 [node name="InteractableDetector" type="Area2D" parent="DetectionAreas"]
-position = Vector2(0, 38)
+position = Vector2(0, 206)
 collision_layer = 0
 collision_mask = 8
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DetectionAreas/InteractableDetector"]
+position = Vector2(0, -167)
 shape = SubResource("RectangleShape2D_d8ltk")
 
 [node name="DrillDetector" type="Area2D" parent="DetectionAreas"]

--- a/src/player/player.tscn
+++ b/src/player/player.tscn
@@ -107,7 +107,6 @@ size = Vector2(112, 336)
 [node name="Player" type="CharacterBody2D"]
 collision_layer = 2
 script = ExtResource("1_lbj7m")
-has_drill = null
 
 [node name="DrillSprite" type="Sprite2D" parent="."]
 scale = Vector2(0.5, 0.5)


### PR DESCRIPTION
- only highlight closest interactable
- only highlight interactables whose "conditions" are satisfied (e.g. an empty clicker holder's condition is that the player has a clicker)
- detect interactables from the feet, allows clickers to be picked up when in front of clicker holders